### PR TITLE
Added setWindowShouldClose function

### DIFF
--- a/include/glex/Application.h
+++ b/include/glex/Application.h
@@ -27,6 +27,7 @@ public:
     void clear();
     void swapBuffers();
     int windowShouldClose();
+    void setWindowShouldClose();
     void handleInput();
     void addInputHandler(InputHandler* inputHandler);
     void removeInputHandler(InputHandler* inputHandler);

--- a/src/Application_glfw.cpp
+++ b/src/Application_glfw.cpp
@@ -68,6 +68,10 @@ int Application::windowShouldClose() {
     return glfwWindowShouldClose(_window);
 }
 
+void Application::setWindowShouldClose() {
+    glfwSetWindowShouldClose(_window, -1);
+}
+
 void Application::_updateWindowSize() {
     glfwGetWindowSize(_window, &_windowWidth, &_windowHeight);
 }


### PR DESCRIPTION
When used, this should shutdown the application properly (exit main loop and tidy up if necessary). Right now ESC will trigger a hard exit, possible cleanups after the main loop are simply ignored.