### PR TITLE
Fixed Cube class

### DIFF
--- a/include/glex/Cube.h
+++ b/include/glex/Cube.h
@@ -6,18 +6,16 @@ class Cube {
 public:
     Cube();
     ~Cube();
-    Cube(const std::string texturePath);
+    Cube(Texture* texture);
     void draw();
-
-    Texture* GetTexture();
-
+    Texture* getTexture();
+    void setTexture(Texture* texture);
 
 private:
     GLfloat _anglex = 0.0;
     GLfloat _angley = 0.0;
     GLfloat _anglez = 0.0;
     Texture* _texture = nullptr;
-    
+
     void _drawList();
-    void _initTexture();
 };

--- a/src/Cube.cpp
+++ b/src/Cube.cpp
@@ -2,27 +2,22 @@
 #include "glex/common/log.h"
 
 Cube::Cube() {
-    _initTexture();
 }
 
 Cube::~Cube() {
     DEBUG_PRINTLN("Destroy Cube!");
-    if (_texture != nullptr)
-        delete _texture;
 }
 
-Cube::Cube(const std::string texturePath) {
-    _initTexture();
-    _texture->loadRGB(texturePath);
+Cube::Cube(Texture* texture) {
+    setTexture(texture);
 }
 
-Texture* Cube::GetTexture() {
+Texture* Cube::getTexture() {
     return _texture;
 }
 
-void Cube::_initTexture() {
-    if (_texture == nullptr)
-        _texture = new Texture();
+void Cube::setTexture(Texture* texture) {
+    _texture = texture;
 }
 
 void Cube::_drawList() {


### PR DESCRIPTION
- Instead of passing the path to a texture and load it within the cube class, we should just pass the texture pointer itself
- Added setTexture function (which is also used by the constructor)